### PR TITLE
fix(env): return error when the env file is missing

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -60,13 +60,8 @@ func GetEnv[T any](key string, options ...Option) T {
 	}
 }
 
-// LoadEnvsFromFile loads environment variables from a file and panics if there are any errors.
-func LoadEnvsFromFile(envFile string) {
-	if envFile == "" {
-		return
-	}
-
-	if err := godotenv.Load(envFile); err != nil {
-		panic(fmt.Sprintf("failed to load environment variables from file %s: %v", envFile, err))
-	}
+// LoadEnvsFromFile loads environment variables from the specified environment file(s).
+// If a file is not found, it returns without an error.
+func LoadEnvsFromFile(envFile ...string) error {
+	return godotenv.Load(envFile...)
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -75,8 +75,9 @@ func TestLoadEnvsFromFileSuccess(t *testing.T) {
 		t.Fatalf("Failed to create test .env file: %v", err)
 	}
 
-	env.LoadEnvsFromFile(envPath)
+	err = env.LoadEnvsFromFile(envPath)
 
+	assert.NoError(t, err)
 	assert.Equal(t, "bar", os.Getenv("FOO"))
 }
 
@@ -84,13 +85,11 @@ func TestLoadEnvsFromFileFileNotFound(t *testing.T) {
 	tempDir := t.TempDir()
 	envPath := filepath.Join(tempDir, "file-not-exists.env")
 
-	assert.Panics(t, func() {
-		env.LoadEnvsFromFile(envPath)
-	})
+	err := env.LoadEnvsFromFile(envPath)
+	assert.Error(t, err)
 }
 
 func TestLoadEnvsFromFileEmptyPath(t *testing.T) {
-	assert.NotPanics(t, func() {
-		env.LoadEnvsFromFile("")
-	})
+	err := env.LoadEnvsFromFile()
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Description

This PR returns an error when the `.env` file is missing. The reason behind this change is that in production, we do not have the `.env` file. However, the default environment file is set to `.env` for development purposes, which causes a panic in services on deployment.
