### PR TITLE
chore(repo): migrate module path to pactus

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 ezeX.io
+Copyright (c) 2025 Pactus Blockchain
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ Reusable golang packages
 - [http-middleware](middleware/http-mdl)
 
 ```shell
-go get -u github.com/ezex-io/gopkg/middleware/http-mdl
+go get -u github.com/pactus/gopkg/middleware/http-mdl
 ```
 
 - [logger](logger): provides a set of helper functions for different level of program logs.
 
 ```shell
-go get -u github.com/ezex-io/gopkg/logger
+go get -u github.com/pactus/gopkg/logger
 ```
 
 - [env](env): provides a set of helper functions for dealing with env files.
 
 ```shell
-go get -u github.com/ezex-io/gopkg/env
+go get -u github.com/pactus/gopkg/env
 ```
 
 - [testsuite](testsuite): provides a set of helper functions for testing purposes.
 
 ```shell
-go get -u github.com/ezex-io/gopkg/testsuite
+go get -u github.com/pactus/gopkg/testsuite
 ```

--- a/cache/basic.go
+++ b/cache/basic.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ezex-io/gopkg/scheduler"
+	"github.com/pactus/gopkg/scheduler"
 )
 
 type BasicCache[K any, V any] struct {

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -1,7 +1,7 @@
-module github.com/ezex-io/gopkg/cache
+module github.com/pactus/gopkg/cache
 
 go 1.25.1
 
-require github.com/ezex-io/gopkg/scheduler v0.0.0-20260120175238-90dc637d8ae0
+require github.com/pactus/gopkg/scheduler v0.0.0-20260120175238-90dc637d8ae0
 
 require golang.org/x/sync v0.19.0 // indirect

--- a/cache/go.sum
+++ b/cache/go.sum
@@ -1,4 +1,4 @@
-github.com/ezex-io/gopkg/scheduler v0.0.0-20260120175238-90dc637d8ae0 h1:dN/eNNDTIIXekNU1kCg92yc6sSFJwv9Tb62RXtnFdvQ=
-github.com/ezex-io/gopkg/scheduler v0.0.0-20260120175238-90dc637d8ae0/go.mod h1:I5PLJTun10b6UvzR2s2oA2++QDsQQbUVVbKQDABLkSI=
+github.com/pactus/gopkg/scheduler v0.0.0-20260120175238-90dc637d8ae0 h1:dN/eNNDTIIXekNU1kCg92yc6sSFJwv9Tb62RXtnFdvQ=
+github.com/pactus/gopkg/scheduler v0.0.0-20260120175238-90dc637d8ae0/go.mod h1:I5PLJTun10b6UvzR2s2oA2++QDsQQbUVVbKQDABLkSI=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ezex-io/gopkg/env"
+	"github.com/pactus/gopkg/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/env/go.mod
+++ b/env/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/env
+module github.com/pactus/gopkg/env
 
 go 1.25.1
 

--- a/evm/go.mod
+++ b/evm/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/evm
+module github.com/pactus/gopkg/evm
 
 go 1.25.1
 

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/logger
+module github.com/pactus/gopkg/logger
 
 go 1.25.1
 

--- a/middleware/http-mdl/README.md
+++ b/middleware/http-mdl/README.md
@@ -7,7 +7,7 @@ Common go http server middlewares
 package main
 
 import (
-	middleware "github.com/ezex-io/gopkg/middleware/http-mdl"
+	middleware "github.com/pactus/gopkg/middleware/http-mdl"
 	"net/http"
 )
 
@@ -18,7 +18,7 @@ func main() {
 	sv := &http.Server{
 		Handler: mux,
     }
-	
+
 	sv.ListenAndServe()
 }
 ```

--- a/middleware/http-mdl/go.mod
+++ b/middleware/http-mdl/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/middleware/http-mdl
+module github.com/pactus/gopkg/middleware/http-mdl
 
 go 1.25.1
 

--- a/pipeline/go.mod
+++ b/pipeline/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/pipeline
+module github.com/pactus/gopkg/pipeline
 
 go 1.25.1
 

--- a/retry/go.mod
+++ b/retry/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/retry
+module github.com/pactus/gopkg/retry
 
 go 1.25.1
 

--- a/scheduler/after_test.go
+++ b/scheduler/after_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ezex-io/gopkg/scheduler"
+	"github.com/pactus/gopkg/scheduler"
 )
 
 func TestAfterNotCanceled(t *testing.T) {

--- a/scheduler/every_test.go
+++ b/scheduler/every_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ezex-io/gopkg/scheduler"
+	"github.com/pactus/gopkg/scheduler"
 )
 
 func TestEveryNotCanceled(t *testing.T) {

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/scheduler
+module github.com/pactus/gopkg/scheduler
 
 go 1.25.1
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ezex-io/gopkg/scheduler"
+	"github.com/pactus/gopkg/scheduler"
 )
 
 type testJob struct {

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,3 +1,3 @@
-module github.com/ezex-io/gopkg/signal
+module github.com/pactus/gopkg/signal
 
 go 1.25.1

--- a/testsuite/go.mod
+++ b/testsuite/go.mod
@@ -1,3 +1,3 @@
-module github.com/ezex-io/gopkg/testsuite
+module github.com/pactus/gopkg/testsuite
 
 go 1.25.1

--- a/util/go.mod
+++ b/util/go.mod
@@ -1,4 +1,4 @@
-module github.com/ezex-io/gopkg/util
+module github.com/pactus/gopkg/util
 
 go 1.25.1
 


### PR DESCRIPTION
## Summary

Migrate all module and import paths from `github.com/ezex-io/gopkg` to `github.com/pactus/gopkg`.

## Changes

- **go.mod files**: Rename module paths across all 11 subpackages
- **Import paths**: Update all Go source file imports to the new path
- **LICENSE**: Update copyright holder from `ezeX.io` to `Pactus Blockchain`
- **README.md**: Update install URLs to reflect the new module path

## Verification

- No remaining references to `ezex-io` or `ezeX.io` in the codebase
- All CI workflow files already reference the new org