### PR TITLE
fix(logger): remove file target from defaults, set default level to debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ todo
 .*.sw*
 
 .env
+
+# Go workspace sum (local only)
+go.work.sum

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -2,6 +2,6 @@ module github.com/pactus-project/gopkg/cache
 
 go 1.25.1
 
-require github.com/pactus-project/gopkg/scheduler v0.0.0-20260625084706-612d6d2bb21d
+require github.com/pactus-project/gopkg/scheduler v0.0.0-20260625183600-ce8c076c1e12
 
 require golang.org/x/sync v0.21.0 // indirect

--- a/cache/go.sum
+++ b/cache/go.sum
@@ -1,4 +1,4 @@
-github.com/pactus-project/gopkg/scheduler v0.0.0-20260625084706-612d6d2bb21d h1:0T9u0241FiCIUcCTvpFeKsGd44fRcqFkcPNtk1/u5Gs=
-github.com/pactus-project/gopkg/scheduler v0.0.0-20260625084706-612d6d2bb21d/go.mod h1:R411cuOZcqs2wUZtFaVlV4dCMzqkyWeurlIE//w5/wQ=
+github.com/pactus-project/gopkg/scheduler v0.0.0-20260625183600-ce8c076c1e12 h1:gZQbaLAPpw9li2PG57qXEaAsnFHKUbC9aOzUWbdrAqc=
+github.com/pactus-project/gopkg/scheduler v0.0.0-20260625183600-ce8c076c1e12/go.mod h1:R411cuOZcqs2wUZtFaVlV4dCMzqkyWeurlIE//w5/wQ=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=

--- a/logger/config.go
+++ b/logger/config.go
@@ -23,11 +23,11 @@ func DefaultConfig() *Config {
 		MaxBackups:         0,
 		RotateLogAfterDays: 1,
 		Compress:           true,
-		Targets:            []string{"console", "file"},
+		Targets:            []string{"console"},
 		Levels:             make(map[string]string),
 	}
 
-	conf.Levels["default"] = "info"
+	conf.Levels["default"] = "debug"
 
 	return conf
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -77,7 +77,7 @@ func TestLogger(t *testing.T) {
 	log.Logger = log.Output(&buf)
 
 	Trace("msg", "trace", "trace")
-	Debug("msg", "trace", "trace")
+	Debug("msg", "Debug", "Debug")
 	Info("msg", nil)
 	Info("msg", "a", nil)
 	Info("msg", "b", []byte{1, 2, 3})
@@ -89,7 +89,7 @@ func TestLogger(t *testing.T) {
 	t.Log(out)
 
 	assert.NotContains(t, out, "trace")
-	assert.NotContains(t, out, "debug")
+	assert.Contains(t, out, "debug")
 	assert.Contains(t, out, "foo")
 	assert.Contains(t, out, "010203")
 	assert.Contains(t, out, "!INVALID-KEY!")


### PR DESCRIPTION
## Summary

Remove `file` from default targets and change default log level to `debug`.

### Changes
- `Targets` default: `["console", "file"]` → `["console"]`
- `Levels["default"]`: `"info"` → `"debug"`