### PR TITLE
fix(logger): lazy-init global logger to prevent nil panic in NewSubLogger

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,6 +29,14 @@ type logger struct {
 	writer io.Writer
 }
 
+func getGlobalInst(ctx context.Context) *logger {
+	if globalInst == nil {
+		InitGlobalLogger(ctx, DefaultConfig())
+	}
+
+	return globalInst
+}
+
 // InitGlobalLogger initializes the global logger with the given config.
 // The context is used to attach initial fields to the root logger.
 // Subsequent calls are no-ops.

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"testing"
 
@@ -26,14 +25,14 @@ func (Bar) String() string {
 func setupTestLogger(t *testing.T, conf *Config) {
 	t.Helper()
 
-	InitGlobalLogger(context.Background(), conf)
+	InitGlobalLogger(t.Context(), conf)
 }
 
 func TestNilObjLogger(t *testing.T) {
 	conf := DefaultConfig()
 	setupTestLogger(t, conf)
 
-	l := NewSubLogger("test", nil)
+	l := NewSubLogger(t.Context(), "test", nil)
 	var buf bytes.Buffer
 	l.logger = l.logger.Output(&buf)
 
@@ -43,12 +42,25 @@ func TestNilObjLogger(t *testing.T) {
 }
 
 func TestSubLogger(t *testing.T) {
+	var buf bytes.Buffer
+	subLogger := NewSubLogger(t.Context(), "test", Foo{})
+	subLogger.logger = subLogger.logger.Output(&buf)
+
+	subLogger.Info("msg")
+
+	out := buf.String()
+
+	assert.Contains(t, out, "info")
+	assert.Contains(t, out, "msg")
+}
+
+func TestSubLoggerLevel(t *testing.T) {
 	conf := DefaultConfig()
 	conf.Colorful = false
 	setupTestLogger(t, conf)
 
 	globalInst.config.Levels["test"] = "warn"
-	subLogger := NewSubLogger("test", Foo{})
+	subLogger := NewSubLogger(t.Context(), "test", Foo{})
 	var buf bytes.Buffer
 	subLogger.logger = subLogger.logger.Output(&buf)
 
@@ -128,7 +140,7 @@ func TestInvalidLevel(t *testing.T) {
 	log.Logger = log.Logger.Output(&buf1)
 
 	globalInst.config.Levels["test"] = "invalid"
-	l := NewSubLogger("test", Foo{})
+	l := NewSubLogger(t.Context(), "test", Foo{})
 
 	var buf2 bytes.Buffer
 	l.logger = l.logger.Output(&buf2)

--- a/logger/sub_logger.go
+++ b/logger/sub_logger.go
@@ -1,6 +1,10 @@
 package logger
 
-import "github.com/rs/zerolog"
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
 
 // SubLogger is a named child logger that can attach an object
 // (implementing LogStringer) to every message and has its own log level.
@@ -12,16 +16,16 @@ type SubLogger struct {
 
 // NewSubLogger creates a new SubLogger with the given name and optional object.
 // It derives its log level from the global config's Levels map (falling back to "default").
-func NewSubLogger(name string, obj LogStringer) *SubLogger {
+func NewSubLogger(ctx context.Context, name string, obj LogStringer) *SubLogger {
 	sub := &SubLogger{
-		logger: zerolog.New(globalInst.writer).With().Timestamp().Logger(),
+		logger: zerolog.New(getGlobalInst(ctx).writer).With().Ctx(ctx).Timestamp().Logger(),
 		name:   name,
 		obj:    obj,
 	}
 
-	lvlStr := globalInst.config.Levels[name]
+	lvlStr := getGlobalInst(ctx).config.Levels[name]
 	if lvlStr == "" {
-		lvlStr = globalInst.config.Levels["default"]
+		lvlStr = getGlobalInst(ctx).config.Levels["default"]
 	}
 
 	lvl, err := zerolog.ParseLevel(lvlStr)


### PR DESCRIPTION
## Summary

Calling `NewSubLogger` before `InitGlobalLogger` would dereference a nil `globalInst` and panic.

## Changes

- **`getGlobalInst(ctx)` helper** — lazily initializes `globalInst` with `DefaultConfig()` if it has not been explicitly set
- **`NewSubLogger` signature** — now accepts `context.Context` as first argument; all 3 internal accesses to `globalInst` go through `getGlobalInst`
- **New test `TestSubLogger`** — exercises the lazy-init path (no prior explicit `InitGlobalLogger` call)
- **Context forwarding** — `ctx` is also passed to zerolog via `.Ctx(ctx)` so context-attached fields appear in log output automatically

## Verification

- All 10 tests pass
- No external callers of `NewSubLogger` — safe breaking change
- No remaining naked `globalInst` accesses in non-test code